### PR TITLE
Update event triggers on CI actions

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,6 +1,11 @@
 name: clang-format
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -4,6 +4,10 @@ on:
   push:
     paths-ignore:
       - "*.md"
+  pull_request:
+    paths-ignore:
+      - "*.md"
+  workflow_dispatch:
 
 env:
   # Path to the solution file relative to the root of the project.

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -2,6 +2,8 @@ name: cpp-tests
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - "*.md"
   pull_request:

--- a/.github/workflows/reactjs-tests.yml
+++ b/.github/workflows/reactjs-tests.yml
@@ -5,8 +5,14 @@ name: reactjs-tests
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - "*.md"
+  pull_request:
+    paths-ignore:
+      - "*.md"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This includes `on: pull_request` and `on: workflow_dispatch` to CI test triggers. The first will run actions when a branch is converted to a PR (and doesn't trigger the existing `push`). The latter allows Manual triggering of actions on branches.