### PR TITLE
Update cpp_tests action to run on windows-latest (2022)

### DIFF
--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Will allow git workflow action cpp_tests to build with MSBuild 2022