### PR TITLE
Add Stream Deck Plus rotary encoder support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to DCS Interface
+
+Thank you for your interest in contributing to this project!
+
+## Fork Information
+
+This fork adds Stream Deck Plus rotary encoder support to the original project.
+
+### Original Project
+
+- Original Repository: [charlestytler/streamdeck-dcs-interface](https://github.com/charlestytler/streamdeck-dcs-interface)
+- License: GNU General Public License v3.0
+
+## How to Contribute
+
+1. **Fork the repository** on GitHub
+2. **Clone your fork** locally
+3. **Create a feature branch** (`git checkout -b feature/my-new-feature`)
+4. **Make your changes** and commit them with clear messages
+5. **Test your changes** thoroughly
+6. **Push to your fork** (`git push origin feature/my-new-feature`)
+7. **Submit a Pull Request** to the original repository
+
+## Development Guidelines
+
+### Building from Source
+
+Before building, ensure you have:
+- Microsoft Visual Studio 2022 (or Build Tools with Platform Toolset v145)
+- MSBuild added to your PATH
+- npm for Windows
+
+Run the build script:
+```batch
+cd Tools
+.\build_plugin.bat
+```
+
+### Code Style
+
+- C++: Follow existing code conventions in the project
+- JavaScript/HTML: Use consistent indentation and formatting
+- Add comments for complex logic
+
+### Testing
+
+- Test all functionality with actual Stream Deck hardware
+- Verify DCS integration with multiple aircraft modules
+- Run unit tests before submitting (`Test.exe` generated during build)
+
+## Reporting Issues
+
+When reporting issues, please include:
+- Stream Deck model and firmware version
+- DCS World version
+- Steps to reproduce the issue
+- Expected vs actual behavior
+- Any error messages or logs
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the GNU General Public License v3.0, consistent with the original project.
+
+## Acknowledgments
+
+This project builds upon the excellent work of the original author and contributors. All modifications respect the original GPL-3.0 license terms.

--- a/README.md
+++ b/README.md
@@ -28,12 +28,26 @@ There are currently three settings for each Streamdeck button you create:
 
 - DCS Command - Specify which button/switch you want to activate in game (allows setting of any clickable object in a cockpit).
   - Streamdeck buttons support push-button, switch, and increment (dials, levers, etc.) input types.
+  - **Stream Deck Plus rotary encoders** support rotation with separate CW/CCW increment values and encoder press for fixed values.
 - Image Change Settings - Specify a function within the DCS simulation to monitor and change the display of the Streamdeck image conditionally.
   - Examples: Lamps for Warnings/Modes, Switch states
 - Title Text Change Settings - Specify a function in the DCS simulation which will be monitored and its text is displayed as the Streamdeck button Title.
   - Examples: UFC text displays, scratchpads, radio displays
 
-Can also support multiple physical Streamdecks at once.
+Can also support multiple physical Streamdecks at once, including **Stream Deck Plus** with rotary encoder support.
+
+## Stream Deck Plus Encoder Features
+
+The plugin now supports **Stream Deck Plus rotary encoders** with the following capabilities:
+
+- **Rotation Control**: Separate clockwise (CW) and counter-clockwise (CCW) increment values per tick
+- **Press Action**: Send a fixed value when pressing the encoder button
+- **LCD Display**: Real-time display of DCS values on the encoder LCD screen
+- **Value Mapping**: Map numeric DCS values to custom text (e.g., "0.2" → "OFF", "0.8" → "ARMED")
+- **Automatic Gauge**: Visual indicator bar based on minimum/maximum value ranges
+- **Live Updates**: Changes to mappings take effect immediately without restart
+
+Configure encoders using the dedicated Property Inspector with intuitive controls for all settings.
 
 ## Detailed Documentation
 
@@ -125,4 +139,6 @@ Before running the .bat file you will need to:
 
 Running the batch script will build the Streamdeck plugin and run all unit tests, generating the plugin file at `Release/com.ctytler.dcs.streamDeckPlugin`.
 
-Current version was built with Visual Studio Community 2022.
+**Build Requirements:**
+- Visual Studio 2022 (v17.11+) or Visual Studio 2025 with Platform Toolset v145
+- The encoder support features require Visual Studio 2025 or compatible toolset

--- a/Sources/backend-cpp/ElgatoSD/ElgatoSD.vcxproj
+++ b/Sources/backend-cpp/ElgatoSD/ElgatoSD.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Sources/backend-cpp/SimulatorInterface/SimulatorInterface.vcxproj
+++ b/Sources/backend-cpp/SimulatorInterface/SimulatorInterface.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -173,6 +173,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Utilities\Utilities.vcxproj">
+      <Project>{329f64ac-6346-46d2-a671-9b5dd626b485}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Sources/backend-cpp/StreamdeckContext/SendActions/IncrementAction.cpp
+++ b/Sources/backend-cpp/StreamdeckContext/SendActions/IncrementAction.cpp
@@ -6,6 +6,9 @@
 
 #include "ElgatoSD/EPLJSONUtils.h"
 
+#include <sstream>
+#include <cmath>
+
 void IncrementAction::handleButtonPressedEvent(SimulatorInterface *simulator_interface,
                                                ESDConnectionManager *mConnectionManager,
                                                const json &inPayload)
@@ -21,6 +24,124 @@ void IncrementAction::handleButtonPressedEvent(SimulatorInterface *simulator_int
     if (send_command) {
         simulator_interface->send_command(send_address, send_command.value());
     }
+}
+
+std::string IncrementAction::getCurrentDisplayValue(SimulatorInterface *simulator_interface, const json &settings)
+{
+    const auto dcs_id_increment_monitor_str = EPLJSONUtils::GetStringByName(settings, "dcs_id_increment_monitor");
+    
+    if (is_integer(dcs_id_increment_monitor_str)) {
+        const int dcs_id = std::stoi(dcs_id_increment_monitor_str);
+        const std::optional<Decimal> maybe_value = simulator_interface->get_value_at_addr(dcs_id);
+        
+        if (maybe_value.has_value()) {
+            const std::string raw_value = maybe_value.value().str();
+            
+            // Check if there's a value-to-text mapping
+            const auto mapping_str = EPLJSONUtils::GetStringByName(settings, "encoder_value_text_mapping");
+            
+            if (!mapping_str.empty()) {
+                // Parse the mapping format: "value1:text1;value2:text2;..."
+                std::istringstream mapping_stream(mapping_str);
+                std::string pair;
+                
+                while (std::getline(mapping_stream, pair, ';')) {
+                    // Find the colon separator
+                    size_t colon_pos = pair.find(':');
+                    if (colon_pos != std::string::npos) {
+                        std::string map_value = pair.substr(0, colon_pos);
+                        std::string map_text = pair.substr(colon_pos + 1);
+                        
+                        // Remove any formatting remnants (|color:|size:) from old format
+                        size_t pipe_pos = map_text.find('|');
+                        if (pipe_pos != std::string::npos) {
+                            map_text = map_text.substr(0, pipe_pos);
+                        }
+                        
+                        // Trim whitespace
+                        map_value.erase(0, map_value.find_first_not_of(" \t\n\r"));
+                        map_value.erase(map_value.find_last_not_of(" \t\n\r") + 1);
+                        map_text.erase(0, map_text.find_first_not_of(" \t\n\r"));
+                        map_text.erase(map_text.find_last_not_of(" \t\n\r") + 1);
+                        
+                        // Compare values (with tolerance for floating point)
+                        if (is_number(map_value)) {
+                            Decimal map_decimal(map_value);
+                            Decimal current_decimal(raw_value);
+                            
+                            // Check if values match (within a small tolerance)
+                            Decimal diff = (map_decimal > current_decimal) ? (map_decimal - current_decimal) : (current_decimal - map_decimal);
+                            if (std::stod(diff.str()) < 0.0001) {
+                                return map_text;
+                            }
+                        }
+                    }
+                }
+            }
+            
+            // No mapping found, return raw value
+            return raw_value;
+        }
+    }
+    
+    return "";
+}
+
+std::string IncrementAction::getCurrentImagePath(SimulatorInterface *simulator_interface, const json &settings)
+{
+    const auto dcs_id_increment_monitor_str = EPLJSONUtils::GetStringByName(settings, "dcs_id_increment_monitor");
+    
+    if (is_integer(dcs_id_increment_monitor_str)) {
+        const int dcs_id = std::stoi(dcs_id_increment_monitor_str);
+        const std::optional<Decimal> maybe_value = simulator_interface->get_value_at_addr(dcs_id);
+        
+        if (maybe_value.has_value()) {
+            const std::string raw_value = maybe_value.value().str();
+            
+            // Check if there's a value-to-image mapping
+            const auto mapping_str = EPLJSONUtils::GetStringByName(settings, "encoder_value_text_mapping");
+            
+            if (!mapping_str.empty()) {
+                // Parse the mapping format: "value1:text1;value2:IMG:imagepath;..."
+                std::istringstream mapping_stream(mapping_str);
+                std::string pair;
+                
+                while (std::getline(mapping_stream, pair, ';')) {
+                    // Find the colon separator
+                    size_t colon_pos = pair.find(':');
+                    if (colon_pos != std::string::npos) {
+                        std::string map_value = pair.substr(0, colon_pos);
+                        std::string map_content = pair.substr(colon_pos + 1);
+                        
+                        // Trim whitespace
+                        map_value.erase(0, map_value.find_first_not_of(" \t\n\r"));
+                        map_value.erase(map_value.find_last_not_of(" \t\n\r") + 1);
+                        map_content.erase(0, map_content.find_first_not_of(" \t\n\r"));
+                        map_content.erase(map_content.find_last_not_of(" \t\n\r") + 1);
+                        
+                        // Check if this is an image mapping (format: IMG:path)
+                        if (map_content.substr(0, 4) == "IMG:") {
+                            std::string image_path = map_content.substr(4);
+                            
+                            // Compare values (with tolerance for floating point)
+                            if (is_number(map_value)) {
+                                Decimal map_decimal(map_value);
+                                Decimal current_decimal(raw_value);
+                                
+                                // Check if values match (within a small tolerance)
+                                Decimal diff = (map_decimal > current_decimal) ? (map_decimal - current_decimal) : (current_decimal - map_decimal);
+                                if (std::stod(diff.str()) < 0.0001) {
+                                    return image_path;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    return "";
 }
 
 void IncrementAction::handleButtonReleasedEvent(SimulatorInterface *simulator_interface,
@@ -45,4 +166,98 @@ std::optional<std::string> IncrementAction::determineSendValue(const json &setti
         return value.str();
     }
     return std::nullopt;
+}
+
+void IncrementAction::handleEncoderRotation(SimulatorInterface *simulator_interface,
+                                           ESDConnectionManager *mConnectionManager,
+                                           const json &inPayload,
+                                           int ticks)
+{
+    const auto settings = inPayload["settings"];
+    const auto send_address = EPLJSONUtils::GetStringByName(settings, "send_address");
+    const auto increment_cw_str = EPLJSONUtils::GetStringByName(settings, "increment_cw");
+    const auto increment_ccw_str = EPLJSONUtils::GetStringByName(settings, "increment_ccw");
+    const auto increment_min_str = EPLJSONUtils::GetStringByName(settings, "increment_min");
+    const auto increment_max_str = EPLJSONUtils::GetStringByName(settings, "increment_max");
+    const bool cycling_is_allowed = EPLJSONUtils::GetBoolByName(settings, "increment_cycle_allowed_check");
+
+    // Debug logging
+    mConnectionManager->LogMessage("[Encoder Rotation] send_address: " + send_address);
+    mConnectionManager->LogMessage("[Encoder Rotation] increment_cw: " + increment_cw_str);
+    mConnectionManager->LogMessage("[Encoder Rotation] increment_ccw: " + increment_ccw_str);
+    mConnectionManager->LogMessage("[Encoder Rotation] min: " + increment_min_str + " max: " + increment_max_str);
+    mConnectionManager->LogMessage("[Encoder Rotation] ticks: " + std::to_string(ticks));
+
+    // Update increment monitor with current game state
+    increment_monitor_.update_settings(settings);
+    increment_monitor_.update(simulator_interface);
+
+    // Choose the appropriate increment value based on rotation direction
+    std::string increment_value_str;
+    if (ticks > 0) {
+        // Clockwise rotation
+        increment_value_str = increment_cw_str;
+        mConnectionManager->LogMessage("[Encoder Rotation] Direction: CW, using increment_cw");
+    } else if (ticks < 0) {
+        // Counter-clockwise rotation
+        increment_value_str = increment_ccw_str;
+        mConnectionManager->LogMessage("[Encoder Rotation] Direction: CCW, using increment_ccw");
+    } else {
+        // No rotation
+        mConnectionManager->LogMessage("[Encoder Rotation] No rotation (ticks = 0), ignoring");
+        return;
+    }
+
+    if (is_number(increment_value_str) && is_number(increment_min_str) && is_number(increment_max_str)) {
+        const Decimal increment_value(increment_value_str);
+        
+        // Use absolute value of ticks since direction is already handled by choosing CW or CCW value
+        const Decimal delta_cmd = increment_value * Decimal(std::to_string(std::abs(ticks)));
+        
+        const auto value = increment_monitor_.get_increment_after_command(delta_cmd,
+                                                                          Decimal(increment_min_str),
+                                                                          Decimal(increment_max_str),
+                                                                          cycling_is_allowed);
+        mConnectionManager->LogMessage("[Encoder Rotation] Sending value: " + value.str() + " to address: " + send_address);
+        simulator_interface->send_command(send_address, value.str());
+    } else {
+        mConnectionManager->LogMessage("[Encoder Rotation] Invalid settings - not all values are numbers");
+    }
+}
+
+void IncrementAction::handleEncoderPress(SimulatorInterface *simulator_interface,
+                                        ESDConnectionManager *mConnectionManager,
+                                        const json &inPayload)
+{
+    const auto settings = inPayload["settings"];
+    const auto send_address = EPLJSONUtils::GetStringByName(settings, "send_address");
+    
+    // Debug logging
+    mConnectionManager->LogMessage("[Encoder Press] send_address: " + send_address);
+    
+    // Verify send_address is not empty
+    if (send_address.empty()) {
+        mConnectionManager->LogMessage("[Encoder Press] send_address is empty - cannot send command");
+        return;
+    }
+    
+    // Check if there's a fixed value setting for encoder press (e.g., "encoder_press_value")
+    const auto encoder_press_value_str = EPLJSONUtils::GetStringByName(settings, "encoder_press_value");
+    
+    mConnectionManager->LogMessage("[Encoder Press] encoder_press_value: " + encoder_press_value_str);
+    
+    if (!encoder_press_value_str.empty()) {
+        // Send the fixed value configured for encoder press
+        mConnectionManager->LogMessage("[Encoder Press] Sending fixed value: " + encoder_press_value_str);
+        simulator_interface->send_command(send_address, encoder_press_value_str);
+    } else {
+        // Fallback: if no fixed value is set, use increment_min as default (reset to minimum)
+        const auto increment_min_str = EPLJSONUtils::GetStringByName(settings, "increment_min");
+        if (!increment_min_str.empty()) {
+            mConnectionManager->LogMessage("[Encoder Press] Sending min value: " + increment_min_str);
+            simulator_interface->send_command(send_address, increment_min_str);
+        } else {
+            mConnectionManager->LogMessage("[Encoder Press] No value to send - both encoder_press_value and increment_min are empty");
+        }
+    }
 }

--- a/Sources/backend-cpp/StreamdeckContext/SendActions/IncrementAction.h
+++ b/Sources/backend-cpp/StreamdeckContext/SendActions/IncrementAction.h
@@ -29,6 +29,47 @@ class IncrementAction : public SendActionInterface
                                    ESDConnectionManager *mConnectionManager,
                                    const json &inPayload);
 
+    /**
+     * @brief Handles encoder rotation event with direction (positive = clockwise, negative = counter-clockwise).
+     *
+     * @param simulator_interface Interface to simulator containing current game state.
+     * @param mConnectionManager Interface to StreamDeck.
+     * @param inPayload Json payload received with encoder rotation callback.
+     * @param ticks Number of rotation ticks (positive = clockwise, negative = counter-clockwise).
+     */
+    void handleEncoderRotation(SimulatorInterface *simulator_interface,
+                              ESDConnectionManager *mConnectionManager,
+                              const json &inPayload,
+                              int ticks);
+
+    /**
+     * @brief Handles encoder press to set a fixed value.
+     *
+     * @param simulator_interface Interface to simulator containing current game state.
+     * @param mConnectionManager Interface to StreamDeck.
+     * @param inPayload Json payload received with encoder press callback.
+     */
+    void handleEncoderPress(SimulatorInterface *simulator_interface,
+                           ESDConnectionManager *mConnectionManager,
+                           const json &inPayload);
+    /**
+     * @brief Returns the current display value for the encoder LCD.
+     *
+     * @param simulator_interface Interface to simulator containing current game state.
+     * @param settings Json settings from Streamdeck property inspector.
+     * @return Current value as string, or empty string if not available.
+     */
+    std::string getCurrentDisplayValue(SimulatorInterface *simulator_interface, const json &settings);
+
+    /**
+     * @brief Returns the current image path for the encoder background.
+     *
+     * @param simulator_interface Interface to simulator containing current game state.
+     * @param settings Json settings from Streamdeck property inspector.
+     * @return Image path as string, or empty string if not available.
+     */
+    std::string getCurrentImagePath(SimulatorInterface *simulator_interface, const json &settings);
+
   private:
     IncrementMonitor increment_monitor_{}; // Monitors DCS ID to determine the state of an incremental switch.
 

--- a/Sources/backend-cpp/StreamdeckContext/SendActions/SendActionFactory.cpp
+++ b/Sources/backend-cpp/StreamdeckContext/SendActions/SendActionFactory.cpp
@@ -15,6 +15,8 @@ SendActionFactory::SendActionFactory()
     button_action_from_uuid_["com.ctytler.dcs.static.text.one-state"] = ButtonAction::MOMENTARY;
     button_action_from_uuid_["com.ctytler.dcs.increment.dial.two-state"] = ButtonAction::INCREMENT;
     button_action_from_uuid_["com.ctytler.dcs.increment.textdial.two-state"] = ButtonAction::INCREMENT;
+    button_action_from_uuid_["com.ctytler.dcs.encoder.rotary"] = ButtonAction::INCREMENT;
+    button_action_from_uuid_["com.ctytler.dcs.encoder.rotary.text"] = ButtonAction::INCREMENT;
     button_action_from_uuid_["com.ctytler.dcs.up-down.switch.two-state"] = ButtonAction::SWITCH;
 }
 

--- a/Sources/backend-cpp/StreamdeckContext/StreamdeckContext.h
+++ b/Sources/backend-cpp/StreamdeckContext/StreamdeckContext.h
@@ -74,6 +74,30 @@ class StreamdeckContext
                                    ESDConnectionManager *mConnectionManager,
                                    const json &inPayload);
 
+    /**
+     * @brief Handles encoder rotation events.
+     *
+     * @param simulator_interface Interface to simulator containing current game state.
+     * @param mConnectionManager Interface to StreamDeck.
+     * @param payload Json payload received with encoder rotation callback.
+     * @param ticks Number of rotation ticks (positive = clockwise, negative = counter-clockwise).
+     */
+    void handleEncoderRotation(SimulatorInterface *simulator_interface,
+                              ESDConnectionManager *mConnectionManager,
+                              const json &inPayload,
+                              int ticks);
+
+    /**
+     * @brief Handles encoder press events.
+     *
+     * @param simulator_interface Interface to simulator containing current game state.
+     * @param mConnectionManager Interface to StreamDeck.
+     * @param payload Json payload received with encoder press callback.
+     */
+    void handleEncoderPress(SimulatorInterface *simulator_interface,
+                           ESDConnectionManager *mConnectionManager,
+                           const json &inPayload);
+
     static const int NUM_FRAMES_DELAY_FORCED_STATE_UPDATE = 3; // Kept public for unit testing.
 
   private:
@@ -83,6 +107,9 @@ class StreamdeckContext
     // Mutable context state.
     int current_state_ = 0;          // Stored state of the context.
     std::string current_title_ = ""; // Stored title of the context.
+    std::string last_encoder_display_value_ = ""; // Last value displayed on encoder LCD.
+    std::string last_encoder_image_path_ = ""; // Last image path set for encoder background.
+    json settings_;                  // Stored settings for this context.
 
     // Monitors.
     ImageStateMonitor comparison_monitor_{}; // Monitors DCS ID to determine the image state of Streamdeck context.

--- a/Sources/backend-cpp/StreamdeckContext/StreamdeckContext.vcxproj
+++ b/Sources/backend-cpp/StreamdeckContext/StreamdeckContext.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -177,6 +177,20 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ElgatoSD\ElgatoSD.vcxproj">
+      <Project>{f60ca831-72e9-4992-bcfe-12b3387f646b}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\SimulatorInterface\SimulatorInterface.vcxproj">
+      <Project>{2782d849-65f7-4b89-a856-964fd918269a}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\Utilities\Utilities.vcxproj">
+      <Project>{329f64ac-6346-46d2-a671-9b5dd626b485}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Sources/backend-cpp/StreamdeckInterface/StreamdeckInterface.h
+++ b/Sources/backend-cpp/StreamdeckInterface/StreamdeckInterface.h
@@ -35,6 +35,21 @@ class StreamdeckInterface : public ESDBasePlugin
                         const json &inPayload,
                         const std::string &inDeviceID) override;
 
+	void DialRotateForAction(const std::string& inAction,
+		const std::string& inContext,
+		const json& inPayload,
+		const std::string& inDeviceID) override;
+
+	void DialPressForAction(const std::string& inAction,
+		const std::string& inContext,
+		const json& inPayload,
+		const std::string& inDeviceID) override;
+
+	void TouchTapForAction(const std::string& inAction,
+		const std::string& inContext,
+		const json& inPayload,
+		const std::string& inDeviceID) override;
+
     /**
      * The 'willAppear' event is the first event a key will receive, right before it gets showed on your Stream Deck
      * and/or in Stream Deck software.

--- a/Sources/backend-cpp/StreamdeckInterface/StreamdeckInterface.vcxproj
+++ b/Sources/backend-cpp/StreamdeckInterface/StreamdeckInterface.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Sources/backend-cpp/Test/Test.vcxproj
+++ b/Sources/backend-cpp/Test/Test.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -23,7 +23,7 @@
     <Keyword>Win32Proj</Keyword>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Sources/backend-cpp/Utilities/Utilities.vcxproj
+++ b/Sources/backend-cpp/Utilities/Utilities.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Sources/com.ctytler.dcs.sdPlugin/manifest.json
+++ b/Sources/com.ctytler.dcs.sdPlugin/manifest.json
@@ -21,7 +21,15 @@
       "Tooltip": "Button which communicates with DCS-BIOS",
       "UUID": "com.ctytler.dcs.dcs-bios",
       "PropertyInspectorPath": "propertyinspector/dcs_bios_prop_inspector.html",
-      "ShowTitle": false
+      "ShowTitle": false,
+      "Encoder": {
+        "layout": "$A1",
+        "TriggerDescription": {
+          "Rotate": "Rotate to increment/decrement",
+          "Push": "Press to activate",
+          "Touch": "Touch to activate"
+        }
+      }
     },
     {
       "Icon": "images/Chrome_Switch_Low",
@@ -44,7 +52,15 @@
       "Tooltip": "Button press depends on displayed state",
       "UUID": "com.ctytler.dcs.up-down.switch.two-state",
       "PropertyInspectorPath": "propertyinspector/index.html",
-      "ShowTitle": false
+      "ShowTitle": false,
+      "Encoder": {
+        "layout": "$A1",
+        "TriggerDescription": {
+          "Rotate": "Rotate to switch state",
+          "Push": "Press to toggle",
+          "Touch": "Touch to toggle"
+        }
+      }
     },
     {
       "Icon": "images/button_light_on",
@@ -122,7 +138,15 @@
       "SupportedInMultiActions": false,
       "Tooltip": "Incremental input button can be used for dials/switches/multi-position",
       "UUID": "com.ctytler.dcs.increment.dial.two-state",
-      "PropertyInspectorPath": "propertyinspector/index.html"
+      "PropertyInspectorPath": "propertyinspector/index.html",
+      "Encoder": {
+        "layout": "$A1",
+        "TriggerDescription": {
+          "Rotate": "Rotate to increment/decrement",
+          "Push": "Press to activate",
+          "Touch": "Touch to activate"
+        }
+      }
     },
     {
       "Icon": "images/Rotary_Switch_Half_0",
@@ -144,7 +168,61 @@
       "SupportedInMultiActions": false,
       "Tooltip": "Incremental input button with space for text above",
       "UUID": "com.ctytler.dcs.increment.textdial.two-state",
-      "PropertyInspectorPath": "propertyinspector/index.html"
+      "PropertyInspectorPath": "propertyinspector/index.html",
+      "Encoder": {
+        "layout": "$A1",
+        "TriggerDescription": {
+          "Rotate": "Rotate to increment/decrement",
+          "Push": "Press to activate",
+          "Touch": "Touch to activate"
+        }
+      }
+    },
+    {
+      "Icon": "images/Rotary_Dial_0",
+      "Name": "DCS Rotary Encoder",
+      "States": [
+        {
+          "Image": "images/Rotary_Dial_0"
+        }
+      ],
+      "Controllers": ["Encoder"],
+      "SupportedInMultiActions": false,
+      "Tooltip": "Rotary encoder for Stream Deck Plus - Incremental input control",
+      "UUID": "com.ctytler.dcs.encoder.rotary",
+      "PropertyInspectorPath": "propertyinspector/encoder_prop_inspector.html",
+      "Encoder": {
+        "layout": "$B2",
+        "background": "images/Rotary_Dial_0",
+        "TriggerDescription": {
+          "Rotate": "Rotate to increment/decrement value",
+          "Push": "Press encoder to send command",
+          "Touch": "Touch to activate"
+        }
+      }
+    },
+    {
+      "Icon": "images/Rotary_Switch_Half_0",
+      "Name": "DCS Rotary Encoder (Text Display)",
+      "States": [
+        {
+          "Image": "images/Rotary_Switch_Half_0"
+        }
+      ],
+      "Controllers": ["Encoder"],
+      "SupportedInMultiActions": false,
+      "Tooltip": "Rotary encoder with text display for Stream Deck Plus",
+      "UUID": "com.ctytler.dcs.encoder.rotary.text",
+      "PropertyInspectorPath": "propertyinspector/encoder_prop_inspector.html",
+      "Encoder": {
+        "layout": "$B2",
+        "background": "images/Rotary_Switch_Half_0",
+        "TriggerDescription": {
+          "Rotate": "Rotate to increment/decrement value",
+          "Push": "Press encoder to send command",
+          "Touch": "Touch to activate"
+        }
+      }
     }
   ],
   "SDKVersion": 2,

--- a/Sources/com.ctytler.dcs.sdPlugin/propertyinspector/encoder_prop_inspector.html
+++ b/Sources/com.ctytler.dcs.sdPlugin/propertyinspector/encoder_prop_inspector.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport"
+    content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,minimal-ui,viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+  <title>DCS Rotary Encoder Property Inspector</title>
+  <link rel="stylesheet" href="css/sdpi.css" />
+</head>
+
+<body>
+  <div class="sdpi-wrapper">
+    <details open>
+      <summary>Encoder Rotation Settings (Incremental Input)</summary>
+
+      <div class="sdpi-item">
+        <div class="sdpi-item-label">Button ID</div>
+        <input id="button_id" class="sdpi-item-value" type="text" value="" placeholder="Enter number" />
+        <button class="sdpi-item-value" id="clear_dcs_command_button" onclick="callbackClearDcsCommand()"> Clear
+        </button>
+      </div>
+
+      <div class="sdpi-item">
+        <div class="sdpi-item-label">Device ID</div>
+        <input id="device_id" class="sdpi-item-value" type="text" value="" placeholder="Enter number" />
+      </div>
+
+      <div id="increment_button_settings" hidden>
+        <div class="sdpi-item" id="send_increment">
+          <div class="sdpi-item-label">DCS ID (Monitor)</div>
+          <input id="dcs_id_increment_monitor" class="sdpi-item-value" type="text" value=""
+            placeholder="Enter DCS ID to monitor" />
+        </div>
+
+        <div class="sdpi-item" id="send_increment_cw">
+          <div class="sdpi-item-label">Increment CW (Clockwise per tick)</div>
+          <input id="increment_cw" class="sdpi-item-value" type="text" placeholder="Example: 0.1 or -0.1" />
+        </div>
+
+        <div class="sdpi-item" id="send_increment_ccw">
+          <div class="sdpi-item-label">Increment CCW (Counter-Clockwise per tick)</div>
+          <input id="increment_ccw" class="sdpi-item-value" type="text" placeholder="Example: -0.1 or 0.1" />
+        </div>
+
+        <div class="sdpi-item" id="send_increment_range">
+          <div class="sdpi-item-label">Increment range min/max</div>
+          <input id="increment_min" class="sdpi-item-value" type="text" placeholder="Example: 0" />
+          <input id="increment_max" class="sdpi-item-value" type="text" placeholder="Example: 1" />
+        </div>
+
+        <div type="checkbox" class="sdpi-item">
+          <div class="sdpi-item-label">Cycle Settings</div>
+          <input class="sdpi-item-value" id="increment_cycle_allowed_check" type="checkbox" value="check" />
+          <label for="increment_cycle_allowed_check"><span></span>Allow cycling to beginning</label>
+        </div>
+      </div>
+    </details>
+
+    <details open>
+      <summary>Encoder Press Settings (Fixed Value)</summary>
+
+      <div class="sdpi-item">
+        <div class="sdpi-item-label">Value to Send on Press</div>
+        <input id="encoder_press_value" class="sdpi-item-value" type="text" 
+          placeholder="Example: 0 (leave empty to send min value)" 
+          onmouseover="document.getElementById('encoder_press_help').style.display='block'" 
+          onmouseout="document.getElementById('encoder_press_help').style.display='none'" />
+      </div>
+
+      <div id="encoder_press_help" class="sdpi-item" style="margin-top: 8px; font-size: 11px; color: #999; display: none;">
+        <div class="sdpi-item-label" style="max-width: 100%;">
+          When you press the encoder button, this fixed value will be sent. 
+          Leave empty to send the minimum value by default.
+        </div>
+      </div>
+    </details>
+
+    <details>
+      <summary>DCS Display Settings</summary>
+
+      <div class="sdpi-item">
+        <div class="sdpi-item-label">Value Mappings</div>
+        <button class="sdpi-item-value" onclick="addValueMapping()" style="width: 100px;">+ Add</button>
+      </div>
+
+      <div id="value_mappings_container" style="margin-left: 5px; margin-right: 5px;">
+        <!-- Dynamic mapping rows will be added here -->
+      </div>
+
+      <!-- Hidden field to store the serialized mappings -->
+      <input id="encoder_value_text_mapping" type="hidden" />
+<!--
+      <div class="sdpi-item" style="margin-top: 8px; font-size: 11px; color: #999;">
+        <div class="sdpi-item-label" style="max-width: 100%;">
+          Define how DCS values should be displayed on the encoder LCD.
+          Choose between text display or background image for each value.
+        </div>
+      </div>
+      -->
+    </details>
+
+    <details>
+      <summary>Additional Help</summary>
+
+      <div class="sdpi-item">
+        <button class="sdpi-item-value" id="external_id_lookup_window_button" onclick="callbackIdLookupButtonPress()">
+          ID Lookup
+        </button>
+        <button class="sdpi-item-value" id="external_help_window_button" onclick="callbackHelpButtonPress()">
+          Help
+        </button>
+        <button class="sdpi-item-value" id="external_comms_window_button" onclick="callbackCommsSettingsButtonPress()">
+          DCS Comms
+        </button>
+      </div>
+    </details>
+  </div>
+
+  <!-- Hidden divs for compatibility with settings_functions.js -->
+  <div id="momentary_button_settings" hidden></div>
+  <div id="switch_button_settings" hidden></div>
+
+  <div class="sdpi-info-label hidden" style="top: -1000;" value=""></div>
+  <script src="js/common.js"></script>
+  <script src="js/common_pi.js"></script>
+  <script src="js/index_pi.js"></script>
+  <script src="js/settings_functions.js"></script>
+  <script src="js/send_receive_functions.js"></script>
+  <script src="js/external_windows_functions.js"></script>
+
+  <script>
+    let mappingCounter = 0;
+
+    function addValueMapping(dcsValue = '', text = '') {
+      const container = document.getElementById('value_mappings_container');
+      if (!container) {
+        console.error('Container value_mappings_container not found');
+        return;
+      }
+      
+      const rowId = `mapping_row_${mappingCounter++}`;
+      
+      const row = document.createElement('div');
+      row.id = rowId;
+      row.className = 'sdpi-item';
+      row.style.cssText = 'border: 1px solid #444; padding: 6px; margin-bottom: 6px; border-radius: 3px; background: #1e1e1e;';
+      
+      row.innerHTML = `
+        <div style="display: flex; gap: 4px; align-items: center;">
+          <input type="text" placeholder="Value" value="${dcsValue}" 
+            style="width: 60px; padding: 3px; background: #2a2a2a; border: 1px solid #555; color: #ccc; font-size: 11px;" />
+          
+          <input type="text" placeholder="Display Text" value="${text}" 
+            style="flex: 1; padding: 3px; background: #2a2a2a; border: 1px solid #555; color: #ccc; font-size: 11px;" />
+          
+          <button onclick="saveMappingRow('${rowId}')" 
+            style="width: 30px; padding: 3px; background: #0e639c; border: none; color: white; cursor: pointer; border-radius: 3px; font-size: 10px;">
+            ✓
+          </button>
+          
+          <button onclick="removeMapping('${rowId}')" 
+            style="width: 30px; padding: 3px; background: #c41e3a; border: none; color: white; cursor: pointer; border-radius: 3px; font-size: 10px;">
+            ✕
+          </button>
+        </div>
+      `;
+      
+      container.appendChild(row);
+    }
+
+    function removeMapping(rowId) {
+      const row = document.getElementById(rowId);
+      if (row) {
+        row.remove();
+        serializeMappings();
+      }
+    }
+
+    function saveMappingRow(rowId) {
+      const row = document.getElementById(rowId);
+      const saveButton = row.querySelector('button[onclick*="saveMappingRow"]');
+      
+      // Visual feedback
+      const originalBg = saveButton.style.background;
+      saveButton.style.background = '#28a745';
+      saveButton.innerHTML = '✓';
+      
+      // Serialize and save
+      serializeMappings();
+      
+      // Reset button after a short delay
+      setTimeout(() => {
+        saveButton.style.background = originalBg;
+      }, 1000);
+    }
+
+    function serializeMappings() {
+      const container = document.getElementById('value_mappings_container');
+      const rows = container.querySelectorAll('.sdpi-item');
+      const mappings = [];
+      
+      rows.forEach(row => {
+        const inputs = row.querySelectorAll('input');
+        const dcsValue = inputs[0].value.trim();
+        const text = inputs[1].value.trim();
+        
+        if (dcsValue !== '' && text !== '') {
+          mappings.push(`${dcsValue}:${text}`);
+        }
+      });
+      
+      const mappingString = mappings.join(';');
+      const hiddenInput = document.getElementById('encoder_value_text_mapping');
+      hiddenInput.value = mappingString;
+      
+      // Save to settings directly
+      if (typeof settings !== 'undefined') {
+        settings['encoder_value_text_mapping'] = mappingString;
+        if (typeof $SD !== 'undefined' && $SD.api) {
+          console.log('Saving encoder_value_text_mapping:', mappingString);
+          $SD.api.setSettings($SD.uuid, settings);
+          
+          // Send updated settings to plugin immediately
+          if (typeof sendSettingsToPlugin === 'function') {
+            sendSettingsToPlugin();
+          }
+        }
+      }
+    }
+
+    function deserializeMappings(mappingString) {
+      // Clear existing mappings
+      const container = document.getElementById('value_mappings_container');
+      container.innerHTML = '';
+      mappingCounter = 0;
+      
+      if (!mappingString || mappingString.trim() === '') return;
+      
+      const entries = mappingString.split(';');
+      entries.forEach(entry => {
+        const trimmed = entry.trim();
+        if (trimmed === '') return;
+        
+        const colonIndex = trimmed.indexOf(':');
+        if (colonIndex === -1) return;
+        
+        const dcsValue = trimmed.substring(0, colonIndex);
+        let text = trimmed.substring(colonIndex + 1);
+        
+        // Clean up old format with pipes (color/size formatting)
+        const pipeIndex = text.indexOf('|');
+        if (pipeIndex !== -1) {
+          text = text.substring(0, pipeIndex);
+        }
+        
+        addValueMapping(dcsValue, text);
+      });
+    }
+
+    // Hook into settings load
+    document.addEventListener('DOMContentLoaded', function() {
+      // Wait a bit for settings to be loaded by the SDK
+      setTimeout(function() {
+        const hiddenInput = document.getElementById('encoder_value_text_mapping');
+        if (hiddenInput && hiddenInput.value) {
+          console.log('Loading mappings from hidden input:', hiddenInput.value);
+          deserializeMappings(hiddenInput.value);
+        } else {
+          console.log('No mappings to load, hidden input value:', hiddenInput ? hiddenInput.value : 'element not found');
+        }
+      }, 500);
+    });
+
+    // Also hook into the SDK's connected event to reload mappings when settings are received
+    if (typeof $SD !== 'undefined') {
+      $SD.on('connected', function(jsn) {
+        setTimeout(function() {
+          const settings = jsn.actionInfo && jsn.actionInfo.payload && jsn.actionInfo.payload.settings;
+          if (settings && settings.encoder_value_text_mapping) {
+            console.log('Loading mappings from connected event:', settings.encoder_value_text_mapping);
+            deserializeMappings(settings.encoder_value_text_mapping);
+          }
+        }, 100);
+      });
+    }
+
+    // Override the global updateUI function to also update mappings
+    if (typeof window !== 'undefined') {
+      setTimeout(function() {
+        if (typeof updateUI !== 'undefined') {
+          const originalUpdateUI = updateUI;
+          window.updateUI = function(pl) {
+            // Call original first
+            if (originalUpdateUI) {
+              originalUpdateUI(pl);
+            }
+            
+            // Then load mappings
+            if (pl && pl.encoder_value_text_mapping) {
+              console.log('Loading mappings from updateUI:', pl.encoder_value_text_mapping);
+              deserializeMappings(pl.encoder_value_text_mapping);
+            }
+          };
+        }
+      }, 10);
+    }
+  </script>
+
+</body>
+
+</html>


### PR DESCRIPTION
Add Stream Deck Plus rotary encoder support

Features:
- Rotary encoder rotation with separate CW/CCW increment values
- Encoder press support with fixed value
- LCD display using setFeedback API with B2 layout
- Value-to-text mapping system with dynamic UI
- Automatic gauge/indicator based on min/max/current values
- Real-time settings update without restart

Technical changes:
- Add dialRotate, dialDown, dialUp event handlers
- Create encoder_prop_inspector.html for configuration
- Implement getCurrentDisplayValue() with mapping support
- Update manifest.json with two encoder actions
- Upgrade Visual Studio toolset to v145 (VS 2025)
- Update README with encoder features documentation
- Add CONTRIBUTING.md for fork information